### PR TITLE
세미나 삭제, 수정 기능 추가

### DIFF
--- a/app/pages/Seminars.vue
+++ b/app/pages/Seminars.vue
@@ -56,10 +56,14 @@
                 <div class="Seminar__files">
                     <a class="Seminar__file" v-for="source in seminar.sources" :href="source.url"
                         target="_blank" rel="noopener">
-
                         {{ source.name }}
                     </a>
                 </div>
+                <template v-if="seminar.canEdit">
+                    <div class="Seminar__edit">
+                        <a @click="deleteSeminar(seminar)" class="Seminar__delete"> {{ $t('delete-seminar') }} </a>
+                    </div>
+                </template>
             </div>
         </div>
 
@@ -73,6 +77,7 @@
         go-back: '뒤로가기'
         desc: '스팍스에서 진행되었던 세미나의 발표자료입니다.'
         reverse: '역순'
+        delete-seminar: '세미나 삭제'
 </i18n>
 
 <style scoped>
@@ -212,6 +217,23 @@
                 background: var(--grey-780);
             }
         }
+
+        &__edit {
+            cursor: pointer;
+            display: inline-block;
+            padding: 5px 12px;
+            margin: 5px 10px;
+            border-radius: 5px;
+            background: var(--alert-level-1);
+            color: var(--alert-foreground-900);
+            font-family: var(--theme-font);
+            text-decoration: none;
+            transition: background .4s ease;
+
+            &:hover {
+                background: var(--alert-level-2);
+            }
+        }
     }
 </style>
 
@@ -322,8 +344,18 @@
         },
 
         methods: {
+            notify(name, result) {
+                this.$store.dispatch('toast/addToastFromApi', { name, result });
+            },
             stringifyDate(date) {
                 return formatDate(date);
+            },
+            async deleteSeminar(seminar) {
+                if (!confirm(`정말 '${seminar.title}'를 삭제하시겠어요?`)) {
+                    return;
+                }
+                const result = await api(`/seminar/${seminar._id}`, 'delete');
+                await this.notify(this.$t('delete-seminar'), result);
             }
         },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,7 +2509,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -3643,8 +3642,7 @@
         "acorn": "7.1.1",
         "elliptic": "6.5.3",
         "es6-promise": "4.2.8",
-        "nan": "2.14.0",
-        "secp256k1": "3.7.1"
+        "nan": "2.14.0"
       },
       "optionalDependencies": {
         "secp256k1": "3.7.1"
@@ -7060,8 +7058,7 @@
         "bson": "^1.1.1",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"
@@ -10944,10 +10941,8 @@
       "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",

--- a/src/schema.js
+++ b/src/schema.js
@@ -28,7 +28,11 @@ const seminarSchema = new Schema({
         },
         name: String,
         url: String
-    }]
+    }],
+    uploaderId: {
+        type: String,
+        required: false
+    }
 });
 seminarSchema.index({ date: -1 });
 


### PR DESCRIPTION
# 작업사항
- 세미나를 업로드한 사용자를 기록합니다 (스팍스 아이디로, Seminar 모델 수정)
- 세미나 수정 API 추가
- 세미나 삭제 API의 권한을 관리자 및 업로드한 사용자로 변경

이렇게 생겼습니다. 수정기능은 추후 UI 추가할 예정입니다.

![스크린샷 2021-05-11 오후 10 16 01](https://user-images.githubusercontent.com/11422210/117821375-7ad49700-b2a6-11eb-8519-f068e0b5fbd9.png)